### PR TITLE
fix: resolve CORS issue with NewsAPI in production

### DIFF
--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const query = searchParams.get('q');
+  
+  if (!query) {
+    return NextResponse.json({ error: 'Query parameter is required' }, { status: 400 });
+  }
+
+  try {
+    // Obtener fechas de búsqueda de noticias (desde - hasta)
+    const currentDate = new Date();
+    const toDate = currentDate.toISOString();
+    currentDate.setDate(currentDate.getDate() - 7);
+    const fromDate = currentDate.toISOString();
+
+    const url = `https://newsapi.org/v2/everything?from=${fromDate}&to=${toDate}&sortBy=publishedAt&language=es&q=${encodeURIComponent(query)}&apiKey=${process.env.NEXT_PUBLIC_NEWS_API_KEY}`;
+
+    const response = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`NewsAPI error: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('API Error:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch news' }, 
+      { status: 500 }
+    );
+  }
+}

--- a/src/utils/NewsApi.ts
+++ b/src/utils/NewsApi.ts
@@ -28,7 +28,7 @@ class NewsApi extends Api {
   }
 
   searchNews(query: string): Promise<NewsApiResponse> {
-    return super._makeRequest<NewsApiResponse>(`&q=${query}`);
+    return super._makeRequest<NewsApiResponse>(`q=${encodeURIComponent(query)}`);
   }
 }
 
@@ -39,8 +39,8 @@ currentDate.setDate(currentDate.getDate() - 7);
 const fromDate = currentDate.toISOString();
 
 export const newsApi = new NewsApi({
-  baseUrl: `https://newsapi.org/v2/everything?from=${fromDate}&to=${toDate}&sortBy=publishedAt&language=es`,
+  baseUrl: '/api/news?',
   headers: {
-    Authorization: `Bearer ${process.env.NEXT_PUBLIC_NEWS_API_KEY}`,
+    'Content-Type': 'application/json',
   },
 });


### PR DESCRIPTION
- Add Next.js API route at /api/news to proxy NewsAPI calls
- Update NewsApi.ts to use internal API route instead of direct NewsAPI calls
- This fixes the 'Failed to fetch' error in Vercel deployment
- NewsAPI free tier only allows localhost, server-side calls work around this